### PR TITLE
Fix validating null values throws exception

### DIFF
--- a/Shared/Query.cs
+++ b/Shared/Query.cs
@@ -6,6 +6,8 @@ namespace Shared
     {
         public string ArgIsEmail([EmailAddress, Required] string email) => email;
 
+        public string ArgIsLimitedString([StringLength(6)] string comment) => comment;
+
         /// <summary>
         /// Gives validation failed result if email already exist. Other wise *You are good to go...*
         /// </summary>

--- a/src/ValidationMiddleware.cs
+++ b/src/ValidationMiddleware.cs
@@ -29,14 +29,14 @@ namespace Graph.ArgumentValidator
                     value is Validate validate)
                 {
                     var input = context.ArgumentValue<object>(argument.Name);
-                    var validationContext = new ValidationContext(input, context.Services, null);
+                    var validationContext = new ValidationContext(input ?? this, context.Services, null);
                     validate(input, validationContext, errors);
 
                     if (errors.Any())
                     {
                         foreach (var validationResult in errors)
                         {
-                            var field = validationResult.MemberNames.FirstOrDefault() ?? argument.Name;
+                            string field = input != null ? validationResult.MemberNames.FirstOrDefault() ?? argument.Name : argument.Name;
 
                             context.ReportError(ErrorBuilder.New()
                                 .SetMessage(validationResult.ErrorMessage)

--- a/test/ValidationTests.cs
+++ b/test/ValidationTests.cs
@@ -51,6 +51,30 @@ namespace Graph.ArgumentValidator.Tests
         }
 
         [Fact]
+        public async Task Ensure_Validation_Works_On_StringObjects_ValidString()
+        {
+            var result = await ExecuteRequest("{ argIsLimitedString(comment: \"123456\") }");
+
+            result.MatchSnapshot();
+        }
+
+        [Fact]
+        public async Task Ensure_Validation_Works_On_StringObjects()
+        {
+            var result = await ExecuteRequest("{ argIsLimitedString(comment: \"1234567\") }");
+
+            result.MatchSnapshot();
+        }
+
+        [Fact]
+        public async Task Ensure_Validation_Works_On_StringObjects_Null()
+        {
+            var result = await ExecuteRequest("{ argIsLimitedString(comment: null) }");
+
+            result.MatchSnapshot();
+        }
+
+        [Fact]
         public async Task Ensure_Validation_Works_On_InputObjects_ValidEmail()
         {
             var result = await ExecuteRequest("{ argIsInput(input: { email: \"abc@abc.com\" }) }");

--- a/test/__snapshots__/ValidationTests.Ensure_Validation_Works_On_StringObjects.snap
+++ b/test/__snapshots__/ValidationTests.Ensure_Validation_Works_On_StringObjects.snap
@@ -1,0 +1,16 @@
+﻿{
+  "errors": [
+    {
+      "message": "The field String must be a string with a maximum length of 6.",
+      "path": [
+        "comment"
+      ],
+      "extensions": {
+        "field": "comment"
+      }
+    }
+  ],
+  "data": {
+    "argIsLimitedString": null
+  }
+}

--- a/test/__snapshots__/ValidationTests.Ensure_Validation_Works_On_StringObjects_Null.snap
+++ b/test/__snapshots__/ValidationTests.Ensure_Validation_Works_On_StringObjects_Null.snap
@@ -1,0 +1,5 @@
+﻿{
+  "data": {
+    "argIsLimitedString": null
+  }
+}

--- a/test/__snapshots__/ValidationTests.Ensure_Validation_Works_On_StringObjects_ValidString.snap
+++ b/test/__snapshots__/ValidationTests.Ensure_Validation_Works_On_StringObjects_ValidString.snap
@@ -1,0 +1,5 @@
+﻿{
+  "data": {
+    "argIsLimitedString": "123456"
+  }
+}


### PR DESCRIPTION
This PR fixes an issue with validating strings when the string is null.

To reproduce, define a GraphQL mutation with a validatable string argument, e.g.:

```C#
    public async Task ExampleMutation([StringLength(6)] string exampleArgument = "")
    {
        ...
    }
```
**Expected/actual behavior:**
* `exampleArgument = null` => expected valid, actually throws `ArgumentNullException` ❌
* `exampleArgument = String.Empty`  => expected valid ✅
* `exampleArgument = "123456"` => expected valid ✅
* `exampleArgument = "1234567"` => expected not valid ✅

**Cause:**
In the middleware a `ValidationContext` is created from the value object. If this is null, the context cannot be created.

**Solution**
When validating values the `ValidationContext` is not relevant. Therefore it can be ommitted by creating a `ValidationContext` from the current instance when the value is null
